### PR TITLE
Owner only get_config

### DIFF
--- a/rs/minter/minter.did
+++ b/rs/minter/minter.did
@@ -83,7 +83,7 @@ service : () -> {
   revoke_admin : (principal) -> ();
   transfer_ownership : (opt principal) -> ();
   transfer_ownership_immediate : (opt principal) -> ();
-  get_ckicp_config : () -> (CkicpConfig) query;
+  get_config : () -> (CkicpConfig) query;
   get_ckicp_state : () -> (CkicpState) query;
   get_funding_subaccount : () -> (vec nat8) query;
   get_funding_account : () -> (text) query;

--- a/rs/minter/src/main.rs
+++ b/rs/minter/src/main.rs
@@ -91,7 +91,12 @@ pub fn post_upgrade() {
 }
 
 #[query]
-pub fn get_ckicp_config() -> CkicpConfig {
+#[modifiers("only_owner")]
+pub fn get_config() -> CkicpConfig {
+    get_ckicp_config()
+}
+
+fn get_ckicp_config() -> CkicpConfig {
     CKICP_CONFIG.with(|ckicp_config| {
         let ckicp_config = ckicp_config.borrow();
         ckicp_config.get().0.clone().unwrap()


### PR DESCRIPTION
Because config contains sensitive data, we make the query owner only.